### PR TITLE
Fix #8 debian version + Fix when docker is the last group of the user.

### DIFF
--- a/launch
+++ b/launch
@@ -8,15 +8,15 @@ if [ "$me" = "root" ]; then
 fi
 
 groups=$(groups)
-if ! echo "$groups" | grep " docker " >/dev/null; then
+if ! echo "$groups" | grep -P "\\bdocker\\b" >/dev/null; then
   printf "You must be in the docker group to use this script.\n"
   exit 1
 fi
 
 # Ensure the base image is created.
-if ! docker images | grep ^my-stretch >/dev/null; then
+if ! docker images | grep ^my-bullseye >/dev/null; then
   # You have to create the base image as root. No automation here.
-  printf "Follow directions in README to build base my-stretch image\n"
+  printf "Follow directions in README to build base my-bullseye image\n"
   exit 1
 fi
 


### PR DESCRIPTION
I found another place where debian stretch was still used.

I also found a bug when `docker` is the last group in the return of `groups` command, and fixed it.